### PR TITLE
Add requested attributes section

### DIFF
--- a/templates/shibboleth_contact_template.xml.j2
+++ b/templates/shibboleth_contact_template.xml.j2
@@ -24,6 +24,19 @@
             </mdui:UIInfo>
         </md:Extensions>
 
+        <md:AttributeConsumingService index="0">
+{% for lang, label in hm_shibboleth__service_name|dictsort %}
+          <md:ServiceName xml:lang="{{ lang }}">{{ label }}</md:ServiceName>
+{% endfor %}
+{% for lang, label in hm_shibboleth__service_description|dictsort %}
+          <md:ServiceDescription xml:lang="{{ lang }}">{{ label }}</md:ServiceDescription>
+{% endfor %}
+          <md:RequestedAttribute FriendlyName="eppn" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+          <md:RequestedAttribute FriendlyName="givenName" Name="urn:oid:2.5.4.42" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+          <md:RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+          <md:RequestedAttribute FriendlyName="sn" Name="urn:oid:2.5.4.4" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+          <md:RequestedAttribute FriendlyName="affiliation" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.9" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"/>
+        </md:AttributeConsumingService>
     </md:SPSSODescriptor>
 
     <md:Organization>


### PR DESCRIPTION
During using original configuration we have observed only identity providers, which hand over useful attributes voluntarily. However, there are others, which do not release any attributes which are not explicitly asked for. So let's add a couple of useful attributes to live with.